### PR TITLE
Add default TaskResult instance in case of nil in executeTask return

### DIFF
--- a/conductorworker.go
+++ b/conductorworker.go
@@ -49,6 +49,9 @@ func NewConductorWorker(baseUrl string, threadCount int, pollingInterval int) *C
 func (c *ConductorWorker) Execute(t *task.Task, executeFunction func(t *task.Task) (*task.TaskResult, error)) {
 	taskResult, err := executeFunction(t)
 	if err != nil {
+		if taskResult == nil {
+			taskResult = task.NewTaskResult(t)
+		}
 		log.Println("Error Executing task:", err.Error())
 		taskResult.Status = task.FAILED
 		taskResult.ReasonForIncompletion = err.Error()

--- a/conductorworker.go
+++ b/conductorworker.go
@@ -14,6 +14,7 @@
 package conductor
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"time"
@@ -55,6 +56,11 @@ func (c *ConductorWorker) Execute(t *task.Task, executeFunction func(t *task.Tas
 		log.Println("Error Executing task:", err.Error())
 		taskResult.Status = task.FAILED
 		taskResult.ReasonForIncompletion = err.Error()
+	}
+
+	if taskResult == nil {
+		log.Println(fmt.Sprintf("'taskResult' cannot be nil on task execution return. taskType=%s", t.TaskType))
+		return
 	}
 
 	taskResultJsonString, err := taskResult.ToJSONString()

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/ggrcha/conductor-go-client
+
+go 1.12


### PR DESCRIPTION
Avoid null pointer errors due to nils returned in TaskResult when there is an error being returned too.